### PR TITLE
Fix conky get-vfo script with patmenu2 update

### DIFF
--- a/conky/get-vfo
+++ b/conky/get-vfo
@@ -3,7 +3,7 @@
 #get VFO of radio to display in conky
 #20200428
 
-source "$HOME/patmenu/config"
+source "$HOME/patmenu2/config"
 
 MAIN () {
 


### PR DESCRIPTION
This PR updates `$HOME/conky/get-vfo` script with `patmenu2` location.

After un-commenting **Radio Freq A** (`VFOA`) and **Radio Freq B** (`VFOB`) lines in `$HOME/.conky` I got this error:

```
/home/pi/bin/conky/get-vfo: line 6: /home/pi/patmenu/config: No such file or directory
/home/pi/bin/conky/get-vfo: line 10: v: command not found
```