### PR TITLE
Hide password fields in BAP script

### DIFF
--- a/build-a-pi
+++ b/build-a-pi
@@ -277,8 +277,8 @@ for the Hot Spot\r</b>NOTE: The last field is the password for the hotspot. You 
 connect to your Pi when it is in hotspot mode <b>This password can only contain letters and numbers</b>" \
 			--title="Build-a-Pi" \
 			--field="Home Wifi SSID":CB "$LIST" \
-			--field="Home Wifi Password" \
-			--field="Hot Spot Password" \
+			--field="Home Wifi Password":H \
+			--field="Hot Spot Password":H \
 			--button="Exit":1 \
 			--button="Continue":2 \
 			--button="Refresh Wifi":3)
@@ -442,7 +442,7 @@ if [ -n "$PATCHECK" ]; then
 		--image ${LOGO} --window-icon=${LOGO} --image-on-top --separator="|" --item-separator="|" \
 		--text="<b>version $VERSION</b>" \
 		--field="Six Character Grid Square" \
-		--field="Winlink Password" \
+		--field="Winlink Password":H \
 		--field="<b>Password is case sensitive</b>":LBL \
 		--button="Continue":2)
 	GRID=$(echo ${INFO} | awk -F "|" '{print $1}')


### PR DESCRIPTION
Text of password fields for 1) Home wifi, 2) Hotspot, and 3) Winlink protected using ":H" attribute.