### PR TITLE
hamlib compile python bindings bug fix

### DIFF
--- a/functions/base.function
+++ b/functions/base.function
@@ -193,6 +193,7 @@ HAMLIB() {
     PACKAGE=hamlib
     CLEANSOURCE
     sudo apt install libusb-1.0-0 libusb-1.0-0-dev
+    pip install swig
     cd ${BUILDDIR} || return
     NEWRIG=$(curl -s https://sourceforge.net/projects/hamlib/files/latest/download |
         grep -o https://downloads.sourceforge.net/project/hamlib/hamlib/[0-9].[0-9] |

--- a/functions/base.function
+++ b/functions/base.function
@@ -206,7 +206,7 @@ HAMLIB() {
     tar -xzf hamlib-${NEWRIG}.tar.gz
     rm hamlib-${NEWRIG}.tar.gz
     cd hamlib-${NEWRIG} || return
-    ./configure
+    ./configure --with-python-binding PYTHON_VERSION='3.9' --prefix=$HOME/local
     make
     sudo make install
     sudo ldconfig

--- a/functions/base.function
+++ b/functions/base.function
@@ -192,8 +192,7 @@ VARA() {
 HAMLIB() {
     PACKAGE=hamlib
     CLEANSOURCE
-    sudo apt install libusb-1.0-0 libusb-1.0-0-dev swig3.0
-    pip install swig
+    sudo apt install libusb-1.0-0 libusb-1.0-0-dev swig
     cd ${BUILDDIR} || return
     NEWRIG=$(curl -s https://sourceforge.net/projects/hamlib/files/latest/download |
         grep -o https://downloads.sourceforge.net/project/hamlib/hamlib/[0-9].[0-9] |

--- a/functions/base.function
+++ b/functions/base.function
@@ -192,7 +192,7 @@ VARA() {
 HAMLIB() {
     PACKAGE=hamlib
     CLEANSOURCE
-    sudo apt install libusb-1.0-0 libusb-1.0-0-dev swig
+    sudo apt install -y libusb-1.0-0 libusb-1.0-0-dev swig
     cd ${BUILDDIR} || return
     NEWRIG=$(curl -s https://sourceforge.net/projects/hamlib/files/latest/download |
         grep -o https://downloads.sourceforge.net/project/hamlib/hamlib/[0-9].[0-9] |

--- a/functions/base.function
+++ b/functions/base.function
@@ -192,7 +192,7 @@ VARA() {
 HAMLIB() {
     PACKAGE=hamlib
     CLEANSOURCE
-    sudo apt install libusb-1.0-0 libusb-1.0-0-dev
+    sudo apt install libusb-1.0-0 libusb-1.0-0-dev swig3.0
     pip install swig
     cd ${BUILDDIR} || return
     NEWRIG=$(curl -s https://sourceforge.net/projects/hamlib/files/latest/download |


### PR DESCRIPTION
this corrects 2 issues with the compile and hamlib python bindings used for pyqso and possible others.