### PR TITLE
Flrig compile error break-fix

### DIFF
--- a/functions/flsuite.function
+++ b/functions/flsuite.function
@@ -26,15 +26,10 @@ FLSTART() {
 	#	DEPENDS
 	##################################
 	#install needed depends
-	#check to see if 32 or 64 bit to detemine correct dependency
-	if [ `getconf LONG_BIT` = '64' ]; then
-	LIBJPG=libjpeg62-turbo-dev
-	else
-	LIBJPG=libjpeg9-dev
-	fi
+	#check to see if libjpeg62 32 or 64 bit to detemine correct dependency -- depricated 2022 single package name
 	sudo apt-get install -y libfltk1.1-dev
 	sudo apt-get install -y build-essential libfltk1.3-dev libsamplerate0-dev portaudio19-dev libsndfile1-dev libxft-dev libxinerama-dev libxcursor-dev libpulse-dev pavucontrol libusb-1.0-0-dev libudev-dev
-	sudo apt-get install -y $LIBJPG portaudio19-dev libusb-1.0-0-dev texinfo
+	sudo apt-get install -y libjpeg62-turbo-dev portaudio19-dev libusb-1.0-0-dev texinfo
 
 	##################################
 	#	FLXMLRPC

--- a/functions/flsuite.function
+++ b/functions/flsuite.function
@@ -33,8 +33,8 @@ FLSTART() {
 	LIBJPG=libjpeg9-dev
 	fi
 	sudo apt-get install -y libfltk1.1-dev
-	sudo apt -y install build-essential libfltk1.3-dev libsamplerate0-dev portaudio19-dev libsndfile1-dev libxft-dev libxinerama-dev libxcursor-dev libpulse-dev pavucontrol libusb-1.0-0-dev
-	sudo apt-get install -y $LIBJPG libxinerama-dev libxcursor-dev libsndfile1-dev libsamplerate0-dev portaudio19-dev libpulse-dev libusb-1.0-0-dev texinfo libudev-dev
+	sudo apt -y install build-essential libfltk1.3-dev libsamplerate0-dev portaudio19-dev libsndfile1-dev libxft-dev libxinerama-dev libxcursor-dev libpulse-dev pavucontrol libusb-1.0-0-dev libudev-dev
+	sudo apt-get install -y $LIBJPG portaudio19-dev libusb-1.0-0-dev texinfo
 
 	##################################
 	#	FLXMLRPC

--- a/functions/flsuite.function
+++ b/functions/flsuite.function
@@ -32,7 +32,9 @@ FLSTART() {
 	else
 	LIBJPG=libjpeg9-dev
 	fi
-	sudo apt-get install -y libfltk1.3-dev $LIBJPG libxft-dev libxinerama-dev libxcursor-dev libsndfile1-dev libsamplerate0-dev portaudio19-dev libpulse-dev libusb-1.0-0-dev texinfo libudev-dev
+	sudo apt-get install -y libfltk1.1-dev 
+	sudo apt-get install -y libfltk1.3-dev 
+	sudo apt-get install -y $LIBJPG libxinerama-dev libxcursor-dev libsndfile1-dev libsamplerate0-dev portaudio19-dev libpulse-dev libusb-1.0-0-dev texinfo libudev-dev
 
 	##################################
 	#	FLXMLRPC

--- a/functions/flsuite.function
+++ b/functions/flsuite.function
@@ -33,7 +33,7 @@ FLSTART() {
 	LIBJPG=libjpeg9-dev
 	fi
 	sudo apt-get install -y libfltk1.1-dev
-	sudo apt -y install build-essential libfltk1.3-dev libsamplerate0-dev portaudio19-dev libsndfile1-dev libxft-dev libxinerama-dev libxcursor-dev libpulse-dev pavucontrol libusb-1.0-0-dev libudev-dev
+	sudo apt-get install -y build-essential libfltk1.3-dev libsamplerate0-dev portaudio19-dev libsndfile1-dev libxft-dev libxinerama-dev libxcursor-dev libpulse-dev pavucontrol libusb-1.0-0-dev libudev-dev
 	sudo apt-get install -y $LIBJPG portaudio19-dev libusb-1.0-0-dev texinfo
 
 	##################################

--- a/functions/flsuite.function
+++ b/functions/flsuite.function
@@ -32,8 +32,8 @@ FLSTART() {
 	else
 	LIBJPG=libjpeg9-dev
 	fi
-	sudo apt-get install -y libfltk1.1-dev 
-	sudo apt-get install -y libfltk1.3-dev 
+	sudo apt-get install -y libfltk1.1-dev
+	sudo apt -y install build-essential libfltk1.3-dev libsamplerate0-dev portaudio19-dev libsndfile1-dev libxft-dev libxinerama-dev libxcursor-dev libpulse-dev pavucontrol libusb-1.0-0-dev
 	sudo apt-get install -y $LIBJPG libxinerama-dev libxcursor-dev libsndfile1-dev libsamplerate0-dev portaudio19-dev libpulse-dev libusb-1.0-0-dev texinfo libudev-dev
 
 	##################################


### PR DESCRIPTION
tested in raspberry desktop on vm but this appears to be a few items a package renamed and I also took examples and notes from the following updated documents 

https://github.com/dslotter/ham_radio_scripts/blob/main/update_fldigi_suite
https://www.hamradioandvision.com/installing-fldigi-for-linux/

I removed the existing logic and placed the depends in a way I found worked for the other issue mentioned in discussions linked here